### PR TITLE
Refresh the dashboard after deleting an order

### DIFF
--- a/client/src/Components/pages/Dashboard.js
+++ b/client/src/Components/pages/Dashboard.js
@@ -93,6 +93,9 @@ export default function Dashboard() {
 
     const userData = await response.json();
     console.log('userData' + userData);
+    
+    /* refresh the dashboard */
+    setUserData({});
 
   }
 


### PR DESCRIPTION
After deleting an order, reset userData (useState) so useEffect can refresh the dashboard.